### PR TITLE
Implement: Add project deletion and restrict seed demo functionality

### DIFF
--- a/client/app/projects/[id]/settings/page.tsx
+++ b/client/app/projects/[id]/settings/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
-import { getProject, updateProject, type Project } from "@/lib/projects";
+import { getProject, updateProject, seedDemoData, deleteProject, type Project } from "@/lib/projects";
 
 export default function ProjectSettingsPage() {
   const params = useParams();
@@ -10,6 +10,9 @@ export default function ProjectSettingsPage() {
   const id = params.id as string;
   const [project, setProject] = useState<Project | null>(null);
   const [saving, setSaving] = useState(false);
+  const [seeding, setSeeding] = useState(false);
+  const [seedResult, setSeedResult] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState(false);
   const [form, setForm] = useState({
     name: "",
     description: "",
@@ -107,6 +110,56 @@ export default function ProjectSettingsPage() {
           {saving ? "Saving..." : "Save Settings"}
         </button>
       </form>
+
+      <section className="mt-8 rounded border bg-gray-50 p-6">
+        <h2 className="mb-2 text-lg font-semibold">Demo Data</h2>
+        <p className="mb-4 text-sm text-gray-600">
+          Populate this project with sample tasks and repositories for testing.
+        </p>
+        {seedResult && (
+          <p className="mb-3 text-sm text-green-600">{seedResult}</p>
+        )}
+        <button
+          onClick={async () => {
+            if (!window.confirm("Seed demo data into this project? This will add sample tasks and repositories.")) return;
+            setSeeding(true);
+            setSeedResult(null);
+            try {
+              await seedDemoData(id);
+              setSeedResult("Demo data seeded successfully.");
+            } finally {
+              setSeeding(false);
+            }
+          }}
+          disabled={seeding}
+          className="rounded border px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 disabled:opacity-50"
+        >
+          {seeding ? "Seeding..." : "Seed Demo Data"}
+        </button>
+      </section>
+
+      <section className="mt-6 rounded border border-red-300 bg-red-50 p-6">
+        <h2 className="mb-2 text-lg font-semibold text-red-700">Danger Zone</h2>
+        <p className="mb-4 text-sm text-red-600">
+          Permanently delete this project and all associated data. This cannot be undone.
+        </p>
+        <button
+          onClick={async () => {
+            if (!window.confirm(`Are you sure you want to delete "${project.name}"? All data will be permanently deleted.`)) return;
+            setDeleting(true);
+            try {
+              await deleteProject(id);
+              router.push("/projects");
+            } finally {
+              setDeleting(false);
+            }
+          }}
+          disabled={deleting}
+          className="rounded bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
+        >
+          {deleting ? "Deleting..." : "Delete Project"}
+        </button>
+      </section>
     </div>
   );
 }

--- a/client/app/projects/page.tsx
+++ b/client/app/projects/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { listProjects, createProject, seedDemoData, type Project } from "@/lib/projects";
+import { listProjects, createProject, deleteProject, type Project } from "@/lib/projects";
 
 export default function ProjectsPage() {
   const [projects, setProjects] = useState<Project[]>([]);
@@ -81,12 +81,13 @@ export default function ProjectsPage() {
               <button
                 onClick={async (e) => {
                   e.preventDefault();
-                  await seedDemoData(p.id);
-                  alert("Demo data seeded!");
+                  if (!window.confirm(`Delete project "${p.name}"? This cannot be undone.`)) return;
+                  await deleteProject(p.id);
+                  setProjects((prev) => prev.filter((x) => x.id !== p.id));
                 }}
-                className="ml-4 shrink-0 rounded border px-3 py-1 text-xs text-gray-600 hover:bg-gray-50"
+                className="ml-4 shrink-0 rounded border px-3 py-1 text-xs text-red-600 hover:bg-red-50"
               >
-                Seed Demo
+                Delete
               </button>
             </div>
           ))}

--- a/client/lib/projects.ts
+++ b/client/lib/projects.ts
@@ -127,3 +127,9 @@ export async function seedDemoData(projectId: string) {
     { method: "POST" }
   );
 }
+
+export async function deleteProject(id: string) {
+  return apiFetch<{ success: boolean }>(`/api/projects/${id}`, {
+    method: "DELETE",
+  });
+}

--- a/service/src/api/routes/projects.ts
+++ b/service/src/api/routes/projects.ts
@@ -37,4 +37,16 @@ export async function projectRoutes(app: FastifyInstance): Promise<void> {
     const updated = repos.projects.update(request.params.id, body);
     return updated;
   });
+
+  app.delete<{ Params: { id: string } }>("/api/projects/:id", async (request, reply) => {
+    const repos = getRepos();
+    const project = repos.projects.findById(request.params.id);
+    if (!project) {
+      reply.code(404).send({ error: "Project not found" });
+      return;
+    }
+
+    repos.projects.delete(request.params.id);
+    return { success: true };
+  });
 }


### PR DESCRIPTION
## Summary

Two improvements needed for project management:

1. Implement project deletion functionality - currently there is no way to delete a project after creation
2. Move "Seed Demo" button to project settings page only and add a confirmation dialog before execution

## Plan

# Implementation Plan: Project Deletion & Seed Demo Restriction

## Overview

Two improvements to project management:

1. **Project deletion** — expose the already-implemented `delete` method in `SqliteProjectRepo` through a new `DELETE /api/projects/:id` REST endpoint, add a `deleteProject` client helper, and add a "Danger Zone" section to the project settings page.
2. **Seed Demo relocation** — remove the "Seed Demo" button from the projects list page (`app/projects/page.tsx`) and add it to the project settings page (`app/projects/[id]/settings/page.tsx`) behind a confirmation dialog.

The SQLite `delete` method already exists and all child tables use `ON DELETE CASCADE` with `foreign_keys = ON`, so the database layer requires no changes.

---

## Files to Modify

### 1. `service/src/api/routes/projects.ts`
**What:** Add a `DELETE /api/projects/:id` route handler.  
**Why:** The `IProjectRepo.delete` and `SqliteProjectRepo.delete` already exist but are not exposed via the API.

The new handler should:
- Retrieve the project by `request.params.id`; return `404` with `{ error: "Project not found" }` if missing (same pattern as the existing `GET` and `PATCH` handlers)
- Call `repos.projects.delete(request.params.id)`
- Return `200` with `{ success: true }` (not `204`) to stay compatible with the existing `apiFetch` utility, which always calls `res.json()`

### 2. `client/lib/projects.ts`
**What:** Add a `deleteProject(id: string)` exported async function.  
**Why:** The client has no function to call the new delete endpoint.

The function should call `apiFetch` with `method: "DELETE"` against `/api/projects/${id}` and return the response typed as `{ success: boolean }`.

Also, remove the `seedDemoData` import from `client/app/projects/page.tsx` (see below) — the function itself stays in this file since it will be needed by the settings page.

### 3. `client/app/projects/page.tsx`
**What:** Remove the "Seed Demo" button from each project card; add a "Delete" button with an inline confirmation flow.  
**Why:** Seed demo should only be accessible from project settings. Project deletion needs a UI entry point; the list page is a natural location for quick access.

Changes:
- Remove the `seedDemoData` import and the `<button>Seed Demo</button>` element from each project card.
- Import and call `deleteProject` from `@/lib/projects`.
- Add a delete button to each project card (e.g., a small red "Delete" button on the right side, alongside where "Seed Demo" currently sits).
- Use a `window.confirm` dialog asking `"Delete project \"${p.name}\"? This cannot be undone."` before calling `deleteProject`. (A `window.confirm` is consistent with how the existing seed demo uses `alert()` — a simple native dialog is appropriate here.)
- On confirmation and success, remove the deleted project from the `projects` state using `setProjects(prev => prev.filter(x => x.id !== p.id))`.

### 4. `client/app/projects/[id]/settings/page.tsx`
**What:** Add two new sections: a "Seed Demo" section and a "Danger Zone" section for project deletion.  
**Why:** Per the task requirements, Seed Demo should live here with a confirmation dialog. Deletion from within settings is the conventional "dangerous action" UX pattern.

Changes:

**Seed Demo section** (add below the existing save-settings form):
- Import `seedDemoData` from `@/lib/projects`.
- Add a `seeding` boolean state variable.
- Render a visually separated section (e.g., `<section>` with a border-top or a gray background panel) labelled "Demo Data".
- Inside it, explain briefly what the action does (e.g., "Populate this project with sample tasks and repositories for testing.").
- Render a "Seed Demo Data" button. On click, show `window.confirm("Seed demo data into this project? This will add sample tasks and repositories.")`. If confirmed, set `seeding(true)`, call `await seedDemoData(id)`, then reset `seeding(false)` and show a success message (e.g., set a transient `string | null` state `seedResult` to display "Demo data seeded successfully.").

**Danger Zone section** (add below the Seed Demo section):
- Import `deleteProject` from `@/lib/projects`.
- Add a `deleting` boolean state variable.
- Render a visually separated "Danger Zone" section with a red/orange border or background, labelled "Danger Zone".
- Inside it, describe the consequence (e.g., "Permanently delete this project and all associated data. This cannot be undone.").
- Render a "Delete Project" button styled in red. On click, show `window.confirm("Are you sure you want to delete \"${project.name}\"? All data will be permanently deleted.")`. If confirmed, set `deleting(true)`, call `await deleteProject(id)`, then `router.push("/projects")`.

---

## Files to Create

No new files are needed.

---

## Implementation Steps

1. **Service — add DELETE endpoint**  
   Open `service/src/api/routes/projects.ts`. After the existing `app.patch(...)` block, add a new `app.delete<{ Params: { id: string } }>("/api/projects/:id", ...)` handler following the same structure as the existing `GET /:id` handler: look up the project, return 404 if missing, call `repos.projects.delete(id)`, return `{ success: true }`.

2. **Client lib — add deleteProject function**  
   Open `client/lib/projects.ts`. After the `updateProject` function, add `deleteProject(id: string)` that calls `apiFetch<{ success: boolean }>` with `method: "DELETE"`.

3. **Client projects list — remove Seed Demo, add Delete**  
   Open `client/app/projects/page.tsx`.  
   - Remove `seedDemoData` from the import on line 5.  
   - Add `deleteProject` to the import.  
   - Replace the `<button onClick={... seedDemoData ...}>Seed Demo</button>` element with a `<button>` that calls `window.confirm(...)` then `deleteProject(p.id)` and filters the project out of local state.  
   - Style the delete button with a red tone to signal destructiveness (e.g., `text-red-600 hover:bg-red-50`).

4. **Client settings page — add Seed Demo + Danger Zone sections**  
   Open `client/app/projects/[id]/settings/page.tsx`.  
   - Add `seedDemoData` and `deleteProject` to the imports from `@/lib/projects`.  
   - Add `seeding`, `deleting`, and `seedResult` state variables.  
   - Below the existing `<form>` closing tag and save button, append the Seed Demo section and the Danger Zone section as described above.

---

## Testing & Validation

1. **Delete via settings page**: Navigate to a project → Settings → click "Delete Project" → cancel (project should remain) → click again → confirm → should redirect to `/projects` and the project should no longer appear in the list.

2. **Delete via projects list**: On the projects list, click the delete button next to a project → cancel (project should remain) → confirm → project card should disappear from the list without a page reload.

3. **Seed Demo via settings page**: Navigate to a project → Settings → click "Seed Demo Data" → cancel (nothing should happen) → confirm → a success message should appear and tasks/repositories should be populated.

4. **Seed Demo removed from list**: Verify the projects list page no longer shows a "Seed Demo" button on any project card.

5. **404 on delete non-existent project**: Calling `DELETE /api/projects/nonexistent-id` should return `404 { error: "Project not found" }`.

6. **Cascade delete**: After deleting a project, verify in the SQLite database (or by attempting to fetch) that associated tasks, repositories, integration settings, plans, channels, etc. are also gone (enforced by the existing `ON DELETE CASCADE` constraints with `foreign_keys = ON`).

---

## Risks & Assumptions

- **Cascade correctness**: All child tables already declare `REFERENCES projects(id) ON DELETE CASCADE` and the database is opened with `foreign_keys = ON`, so a single `DELETE FROM projects WHERE id = ?` is sufficient. No manual cleanup of child records is needed.
- **apiFetch and 204**: The existing `apiFetch` always calls `res.json()`, which would throw on a `204 No Content` response. The new DELETE endpoint must therefore return a JSON body (e.g., `{ success: true }` with status `200`) rather than `204`.
- **Confirmation dialogs**: Using `window.confirm` is consistent with the existing codebase style (the current Seed Demo button uses `alert()`). If the project later adopts a UI component library with modal dialogs, these can be upgraded then.
- **No running-task guard**: This plan does not add a server-side check to prevent deleting a project that has active/running plan runs. If that is desired, it should be noted as a follow-up improvement.
- **Navigation after deletion from settings**: After a successful delete on the settings page, `router.push("/projects")` is used. This assumes the Next.js router is available (it is, via `useRouter()` which is already imported in that page).
