### PR TITLE
Implement: Add manual trigger for channel message pulling

### DIFF
--- a/client/app/projects/[id]/channels/page.tsx
+++ b/client/app/projects/[id]/channels/page.tsx
@@ -7,6 +7,7 @@ import {
   listChannelMessages,
   retryMessage,
   forceTriage,
+  pollChannel,
   updateChannel,
   deleteChannel,
   connectGmail,
@@ -59,6 +60,7 @@ export default function ChannelsPage() {
   const [channelMessages, setChannelMessages] = useState<SourceMessage[]>([]);
   const [loadingMessages, setLoadingMessages] = useState(false);
   const [triaging, setTriaging] = useState(false);
+  const [pollingChannelId, setPollingChannelId] = useState<string | null>(null);
 
   // Edit state
   const [editingChannelId, setEditingChannelId] = useState<string | null>(null);
@@ -149,6 +151,20 @@ export default function ChannelsPage() {
     if (!confirm("Delete this channel? This will also remove all its messages.")) return;
     await deleteChannel(channelId);
     await loadChannels();
+  }
+
+  async function handlePollChannel(ch: ChannelWithCounts) {
+    setPollingChannelId(ch.id);
+    try {
+      await pollChannel(ch.id);
+      await loadChannels();
+      if (expandedChannelId === ch.id) {
+        const msgs = await listChannelMessages(ch.id);
+        setChannelMessages(msgs);
+      }
+    } finally {
+      setPollingChannelId(null);
+    }
   }
 
   async function handleGmailConnect(e: React.FormEvent) {
@@ -627,6 +643,15 @@ export default function ChannelsPage() {
                   >
                     Edit
                   </button>
+                  {ch.kind !== "SLACK" && (
+                    <button
+                      onClick={() => handlePollChannel(ch)}
+                      disabled={pollingChannelId === ch.id || !ch.enabled || editingChannelId === ch.id}
+                      className="rounded px-2 py-1 text-xs text-green-600 hover:bg-green-50 disabled:opacity-50"
+                    >
+                      {pollingChannelId === ch.id ? "Syncing..." : "Sync"}
+                    </button>
+                  )}
                   <button
                     onClick={() => handleToggle(ch)}
                     className={`rounded px-2 py-1 text-xs ${ch.enabled ? "bg-green-100 text-green-700" : "bg-gray-100 text-gray-500"}`}

--- a/client/lib/channels.ts
+++ b/client/lib/channels.ts
@@ -34,6 +34,10 @@ export async function forceTriage(projectId: string) {
   return apiFetch<{ ok: boolean }>(`/api/projects/${projectId}/triage`, { method: "POST" });
 }
 
+export async function pollChannel(channelId: string) {
+  return apiFetch<{ ok: boolean; newMessages: number }>(`/api/channels/${channelId}/poll`, { method: "POST" });
+}
+
 export async function getChannelConfig(channelId: string) {
   return apiFetch<{ id: string; kind: string; name: string; config: Record<string, unknown> }>(
     `/api/channels/${channelId}/config`

--- a/service/src/api/routes/channels.ts
+++ b/service/src/api/routes/channels.ts
@@ -170,6 +170,32 @@ export async function channelRoutes(app: FastifyInstance): Promise<void> {
     }
   );
 
+  // Manually poll a channel now (GMAIL and GITHUB_ISSUES only)
+  app.post<{ Params: { channelId: string } }>(
+    "/api/channels/:channelId/poll",
+    async (request, reply) => {
+      const repos = getRepos();
+      const channel = repos.channels.findById(request.params.channelId);
+      if (!channel) {
+        reply.code(404).send({ error: "Channel not found" });
+        return;
+      }
+
+      if (channel.kind !== "GMAIL" && channel.kind !== "GITHUB_ISSUES") {
+        reply.code(400).send({ error: "Channel kind does not support manual polling" });
+        return;
+      }
+
+      try {
+        const { pollSingleChannel } = await import("../../scheduler/jobs/poll-channels.js");
+        const result = await pollSingleChannel(channel);
+        return { ok: true, newMessages: result.newMessages };
+      } catch (err: any) {
+        reply.code(500).send({ error: err.message });
+      }
+    }
+  );
+
   // Force triage now for a project
   app.post<{ Params: { id: string } }>(
     "/api/projects/:id/triage",

--- a/service/src/scheduler/jobs/poll-channels.ts
+++ b/service/src/scheduler/jobs/poll-channels.ts
@@ -3,12 +3,57 @@ import { getLogger } from "../../lib/logger.js";
 import { GmailChannel } from "../../channels/gmail-channel.js";
 import { GitHubIssuesChannel } from "../../channels/github-issues-channel.js";
 import type { ChannelHandler } from "../../channels/types.js";
+import type { Channel } from "../../types/entities.js";
 import type { ChannelKind } from "../../types/enums.js";
 
 const handlers: Record<string, ChannelHandler> = {
   GMAIL: new GmailChannel(),
   GITHUB_ISSUES: new GitHubIssuesChannel(),
 };
+
+export async function pollSingleChannel(channel: Channel): Promise<{ newMessages: number }> {
+  const log = getLogger();
+  const repos = getRepos();
+
+  const handler = handlers[channel.kind];
+  if (!handler) {
+    throw new Error(`No poll handler for channel kind: ${channel.kind}`);
+  }
+
+  const result = await handler.poll(channel);
+
+  let newMessages = 0;
+
+  // Create source messages, skipping duplicates
+  for (const msg of result.messages) {
+    const existing = repos.sourceMessages.findByChannelAndExternalId(channel.id, msg.external_id);
+    if (existing) continue;
+
+    repos.sourceMessages.create({
+      channel_id: channel.id,
+      project_id: channel.project_id,
+      external_id: msg.external_id,
+      content: msg.content,
+      subject: msg.subject,
+      sender_name: msg.sender_name,
+      sender_email: msg.sender_email,
+      sender_id: msg.sender_id,
+      raw_json: msg.raw_json,
+      received_at: msg.received_at,
+    });
+
+    newMessages++;
+  }
+
+  // Update poll cursor
+  if (result.cursor) {
+    repos.channels.updatePollCursor(channel.id, result.cursor, new Date().toISOString());
+  }
+
+  log.info({ channelId: channel.id, kind: channel.kind, newMessages }, "Channel polled");
+
+  return { newMessages };
+}
 
 export async function runPollChannels(): Promise<void> {
   const log = getLogger();
@@ -19,38 +64,10 @@ export async function runPollChannels(): Promise<void> {
 
   for (const kind of pollableKinds) {
     const channels = repos.channels.listEnabledByKind(kind);
-    const handler = handlers[kind];
-    if (!handler) continue;
 
     for (const channel of channels) {
       try {
-        const result = await handler.poll(channel);
-
-        // Create source messages, skipping duplicates
-        for (const msg of result.messages) {
-          const existing = repos.sourceMessages.findByChannelAndExternalId(channel.id, msg.external_id);
-          if (existing) continue;
-
-          repos.sourceMessages.create({
-            channel_id: channel.id,
-            project_id: channel.project_id,
-            external_id: msg.external_id,
-            content: msg.content,
-            subject: msg.subject,
-            sender_name: msg.sender_name,
-            sender_email: msg.sender_email,
-            sender_id: msg.sender_id,
-            raw_json: msg.raw_json,
-            received_at: msg.received_at,
-          });
-        }
-
-        // Update poll cursor
-        if (result.cursor) {
-          repos.channels.updatePollCursor(channel.id, result.cursor, new Date().toISOString());
-        }
-
-        log.info({ channelId: channel.id, kind, messageCount: result.messages.length }, "Channel polled");
+        await pollSingleChannel(channel);
       } catch (err: any) {
         log.error({ channelId: channel.id, kind, err: err.message }, "Failed to poll channel");
       }


### PR DESCRIPTION
## Summary

Implement functionality to allow manual triggering of message pulls from connected channels (Gmail, Slack, GitHub Issues). This will give users more control over when messages are synchronized instead of relying solely on automated/scheduled pulls.

## Plan

# Implementation Plan: Manual Trigger for Channel Message Pulling

## Overview

Currently, message pulling from Gmail and GitHub Issues channels happens exclusively on an automated schedule every 2 minutes (via `runPollChannels` in the scheduler). Slack uses WebSocket and gets messages in real-time. This plan adds a **per-channel "Pull Now" / "Sync" button** in the UI, backed by a new `POST /api/channels/:channelId/poll` API endpoint, giving users on-demand control over when messages are fetched without waiting for the next scheduler tick.

---

## Files to Modify

### 1. `service/src/scheduler/jobs/poll-channels.ts`
**What:** Refactor the inner per-channel processing logic into a new exported helper function `pollSingleChannel(channel: Channel): Promise<{ newMessages: number }>`.

**Why:** The manual API endpoint needs to reuse the exact same poll-and-persist logic (deduplication, cursor update, logging) that the scheduler uses. Extracting it prevents duplication and ensures consistent behaviour. The existing `runPollChannels()` should be updated to call this helper instead of inlining the logic.

The new `pollSingleChannel` function should:
- Accept a single `Channel` entity
- Look up the appropriate handler from the `handlers` map by `channel.kind`
- Call `handler.poll(channel)`, iterate results, skip duplicates via `repos.sourceMessages.findByChannelAndExternalId`, create new source messages, update the poll cursor, and log the result
- Return `{ newMessages: number }` with the count of newly created messages
- Throw on error (let the caller handle it)

The existing `runPollChannels()` becomes a thin wrapper that iterates over all enabled pollable channels and calls `pollSingleChannel` for each, catching errors per-channel as before.

---

### 2. `service/src/api/routes/channels.ts`
**What:** Add a new `POST /api/channels/:channelId/poll` route.

**Why:** This is the API surface that the client will call for the manual trigger. It follows the same handler pattern as the existing `POST /api/projects/:id/triage` route in the same file.

The route should:
- Look up the channel by `channelId`; return 404 if not found
- Check that `channel.kind` is `"GMAIL"` or `"GITHUB_ISSUES"` (Slack is real-time via WebSocket and has no poll handler); return 400 with `{ error: "Channel kind does not support manual polling" }` otherwise
- Dynamically import `pollSingleChannel` from `../../scheduler/jobs/poll-channels.js` (consistent with how `processTriageBatch` is imported in the triage route)
- Call `pollSingleChannel(channel)` and return `{ ok: true, newMessages: result.newMessages }`
- Catch errors and return 500 with `{ error: err.message }`

---

### 3. `client/lib/channels.ts`
**What:** Add a new exported async function `pollChannel(channelId: string)`.

**Why:** Follows the existing client API helper pattern. Other callers (e.g., the channels page) should not inline `apiFetch` calls.

The function should call `apiFetch<{ ok: boolean; newMessages: number }>(`/api/channels/${channelId}/poll`, { method: "POST" })` and return the result.

---

### 4. `client/app/projects/[id]/channels/page.tsx`
**What:** Add a "Sync" / "Pull Now" button in the channel list row for each pollable channel (GMAIL and GITHUB_ISSUES), with loading state.

**Why:** This is the user-facing control. The existing "Run Triage" button provides the UX precedent — same general pattern (disabled during operation, refreshes data when done).

Specific changes:
- Import `pollChannel` from `@/lib/channels`
- Add a `pollingChannelId` state variable (`string | null`, initially `null`) to track which channel is currently being polled
- Add a `handlePollChannel(ch: ChannelWithCounts)` async handler that:
  1. Sets `pollingChannelId` to `ch.id`
  2. Calls `await pollChannel(ch.id)`
  3. Calls `await loadChannels()` to refresh counts
  4. If the polled channel is currently expanded (`expandedChannelId === ch.id`), also refresh `channelMessages` by calling `listChannelMessages(ch.id)` and updating state
  5. Resets `pollingChannelId` to `null` in a `finally` block
- In the channel list row action buttons area (the `<div className="flex items-center gap-2">` on line ~622), add a "Sync" button after the existing "Edit" button, rendered only when `ch.kind !== "SLACK"`:
  - Disabled when `pollingChannelId === ch.id` (in-progress), when `!ch.enabled`, or when `editingChannelId === ch.id`
  - Label: `pollingChannelId === ch.id ? "Syncing..." : "Sync"`
  - Style: consistent with adjacent action buttons — `rounded px-2 py-1 text-xs text-green-600 hover:bg-green-50 disabled:opacity-50`

---

## Implementation Steps

1. **Refactor `pollSingleChannel`** in `service/src/scheduler/jobs/poll-channels.ts`:
   - Move the body of the inner `for (const channel of channels)` loop into a new exported `async function pollSingleChannel(channel: Channel): Promise<{ newMessages: number }>` 
   - The function should call `handlers[channel.kind]?.poll(channel)`, persist new messages via `repos.sourceMessages`, update the cursor, and return `{ newMessages: count }`
   - Update `runPollChannels()` to call `pollSingleChannel(channel)` and wrap it in the existing try/catch per channel

2. **Add `POST /api/channels/:channelId/poll`** in `service/src/api/routes/channels.ts`:
   - Add the route after the existing `POST /api/messages/:messageId/retry` route and before the `POST /api/projects/:id/triage` route for logical grouping
   - Import `pollSingleChannel` dynamically inside the handler using `await import(...)` (matching the triage route pattern)
   - Validate channel kind; return 400 for SLACK
   - Return `{ ok: true, newMessages: result.newMessages }` on success

3. **Add `pollChannel` function** in `client/lib/channels.ts`:
   - Append after the existing `forceTriage` function for related placement

4. **Update channels page** in `client/app/projects/[id]/channels/page.tsx`:
   - Add `pollChannel` to the import from `@/lib/channels`
   - Add `pollingChannelId` state near the other action-state variables (`triaging`, `editLoading`, etc.)
   - Add `handlePollChannel` async function near the other handlers (`handleToggle`, `handleDelete`, etc.)
   - Render the "Sync" button inside the channel row actions area, guarded by `ch.kind !== "SLACK"`

---

## Testing & Validation

1. **Manual smoke test — Gmail/GitHub Issues channel:**
   - Navigate to a project's Channels page with a Gmail or GitHub Issues channel configured
   - Click "Sync" on the channel — observe the button changes to "Syncing..." while the request is in flight
   - After completion, verify `message_count` and `last_poll_at` reflect the latest poll
   - If the channel's message list is expanded, verify it refreshes with any newly fetched messages

2. **Slack channel — button absent:**
   - Verify no "Sync" button is rendered for Slack channels (real-time via WebSocket)

3. **Disabled channel — button disabled:**
   - Toggle a Gmail channel to "Disabled"
   - Verify the "Sync" button is visually disabled (cannot be clicked)

4. **API-level test:**
   - `POST /api/channels/<valid-gmail-id>/poll` → `200 { ok: true, newMessages: N }`
   - `POST /api/channels/<valid-slack-id>/poll` → `400 { error: "Channel kind does not support manual polling" }`
   - `POST /api/channels/nonexistent/poll` → `404 { error: "Channel not found" }`

5. **Scheduler still works:**
   - Confirm the automated scheduler continues to poll channels every 2 minutes unaffected by the refactor, since `runPollChannels` now delegates to `pollSingleChannel`

---

## Risks & Assumptions

- **Concurrent polls:** The scheduler uses `acquireLock` / `releaseLock` to prevent overlapping scheduler runs, but the manual endpoint will **not** acquire that lock — it runs independently. This means a manual poll can overlap with a scheduled one. This is acceptable because `findByChannelAndExternalId` deduplication prevents double-inserting messages. If stricter serialisation is ever needed, `acquireLock` with a per-channel lock key could be added in a follow-up.
- **Slack is excluded by design:** Slack's `SlackChannel` has no `poll` method in the `handlers` map and receives messages via WebSocket. The 400 guard in the API and the conditional render in the UI enforce this correctly.
- **Error visibility:** The current UI does not surface per-channel error toasts (matching the existing pattern). If `pollChannel` rejects, the `handlePollChannel` handler will silently stop in the `finally` block. A future improvement could add an error state to show a brief error message, but this is out of scope for the initial implementation.
- **Assumption — no authentication middleware:** The new route is added in `channelRoutes` which has no auth middleware (consistent with all other routes in this file and in `service/src/index.ts`).
