### PR TITLE
Implement: Add images to README and user guide documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,20 @@ Messages are collected from three channel types:
 7. **Watch execution**: Live logs via SSE at `/runs/{runId}`
 8. **PRs created automatically** on GitHub with task context
 
+## Screenshots
+
+**Tasks**
+![Tasks](img/tasks.png)
+
+**Channels**
+![Channels](img/channels.png)
+
+**Generated Plan**
+![Generated Plan](img/task-plan-generated.png)
+
+**Execution in Progress**
+![Execution in Progress](img/plan-implementation-in-progress.png)
+
 ### Integrations
 
 **OpenRouter** (for real LLM responses):

--- a/user-guide.html
+++ b/user-guide.html
@@ -224,6 +224,14 @@
       margin-bottom: 1rem;
     }
 
+    .screenshot {
+      max-width: 100%;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      margin-bottom: 1.5rem;
+      display: block;
+    }
+
     footer {
       border-top: 1px solid var(--border);
       padding-top: 2rem;
@@ -300,6 +308,7 @@ pnpm dev</code></pre>
         <tr><td>Integrations</td><td><code>/projects/{id}/integrations</code></td><td>LLM and GitHub setup</td></tr>
         <tr><td>Settings</td><td><code>/projects/{id}/settings</code></td><td>Project configuration</td></tr>
       </table>
+      <img class="screenshot" src="img/tasks.png" alt="Tasks page showing project task list">
     </section>
 
     <!-- 3. Integrations -->
@@ -345,6 +354,7 @@ pnpm dev</code></pre>
         <strong>Important</strong>
         The GitHub OAuth App needs <code>repo</code> scope for full functionality (reading code, creating branches, pushing, creating PRs).
       </div>
+      <img class="screenshot" src="img/repositories.png" alt="Repositories page for selecting GitHub repositories">
     </section>
 
     <!-- 4. Channels -->
@@ -404,6 +414,7 @@ pnpm dev</code></pre>
         <li><strong>Delete</strong>: Remove the channel and stop message collection</li>
         <li><strong>View Messages</strong>: See all collected messages with their triage status</li>
       </ul>
+      <img class="screenshot" src="img/channels.png" alt="Channels page showing configured message channels">
     </section>
 
     <!-- 5. Triage -->
@@ -475,6 +486,7 @@ pnpm dev</code></pre>
           </ul>
         </li>
       </ol>
+      <img class="screenshot" src="img/tasks.png" alt="Task list with pending review items">
 
       <h3>Approving a Task</h3>
       <p>Click <strong>Approve</strong> on a pending task. You can optionally provide instructions that will guide the plan agent:</p>
@@ -484,6 +496,7 @@ pnpm dev</code></pre>
         <li>"Focus only on the backend API, skip UI changes"</li>
       </ul>
       <p>After approval, plan generation starts automatically in the background.</p>
+      <img class="screenshot" src="img/task-generate-plan.png" alt="Task detail with Generate Plan action">
 
       <h3>Task Detail Page</h3>
       <p>Click on any task to see its detail page at <code>/tasks/{taskId}</code>:</p>
@@ -517,6 +530,7 @@ pnpm dev</code></pre>
          EXECUTING ──&gt; DONE / FAILED
                               │
                            Archive</div>
+      <img class="screenshot" src="img/task-plan-processing.png" alt="Plan in draft or awaiting approval state">
 
       <h3>Reviewing a Plan</h3>
       <p>Navigate to a plan from the task detail or plans list. You'll see:</p>
@@ -525,6 +539,7 @@ pnpm dev</code></pre>
         <li>A conversation history with the plan agent</li>
         <li>Action buttons: <strong>Approve</strong>, <strong>Request Changes</strong>, <strong>Reject</strong></li>
       </ul>
+      <img class="screenshot" src="img/task-plan-generated.png" alt="Plan review page with approve, request changes, and reject actions">
 
       <h3>Request Changes</h3>
       <p>If a plan isn't quite right, click <strong>Request Changes</strong> and provide feedback:</p>
@@ -568,6 +583,7 @@ pnpm dev</code></pre>
 
       <h3>Live Logs</h3>
       <p>During execution, you can watch progress in real-time at <code>/runs/{runId}</code>. Logs are streamed via Server-Sent Events (SSE).</p>
+      <img class="screenshot" src="img/plan-implementation-in-progress.png" alt="Live execution log stream during plan execution">
 
       <h3>After the PR is Created</h3>
       <p>OpenAnt continues to monitor the PR:</p>
@@ -580,6 +596,7 @@ pnpm dev</code></pre>
           </ul>
         </li>
       </ul>
+      <img class="screenshot" src="img/plan-completed.png" alt="Completed plan with task marked as DONE and PR created">
 
       <h3>Parallelism</h3>
       <p>You can configure how many plans execute simultaneously per project. Go to <code>/projects/{id}/settings</code> and set the <strong>Max Parallel Runs</strong> value (default: 2, max: 20).</p>


### PR DESCRIPTION
## Summary

Enhance project documentation by adding relevant images:

1. README.md:
- Add selected images from img folder that best demonstrate app usage
- Choose images based on their names to show key functionality

2. user-guide.html:
- Include all available images
- Place images in their corresponding sections

This will improve the visual documentation and make it easier for users to understand the project functionality.

## Plan

# Add Images to README and User Guide Documentation

## Overview

The `img/` folder at the repository root contains 8 application screenshots that are not yet referenced in any documentation. This plan adds those images to `README.md` (selected key screenshots) and to `user-guide.html` (all 8 images placed in their corresponding sections). A new CSS rule for image styling will also be added to the user guide.

---

## Available Images

The following 8 PNG files exist in the `img/` folder at the repository root and will be committed as part of this change:

| Filename | Content |
|---|---|
| `img/tasks.png` | Tasks list view showing pending/open tasks |
| `img/channels.png` | Channels page showing configured message sources |
| `img/repositories.png` | Repositories page showing connected GitHub repos |
| `img/task-generate-plan.png` | Task detail with "Generate Plan" action |
| `img/task-plan-generated.png` | Task detail showing a generated plan ready for review |
| `img/task-plan-processing.png` | Task/plan in the processing/draft state |
| `img/plan-implementation-in-progress.png` | Execution live-log view while a plan is running |
| `img/plan-completed.png` | Completed plan/run with PR created |

---

## Files to Modify

### 1. `README.md`

**What to change:** Add a `## Screenshots` section after the existing `## Workflow` section (before `### Integrations`) with 4 representative images that best demonstrate key app functionality.

**Selected images for README (chosen to show the core end-to-end flow):**
- `img/tasks.png` — the central task management UI (first thing users interact with after triage)
- `img/channels.png` — shows multi-channel input setup
- `img/task-plan-generated.png` — shows LLM-generated implementation plan, a key differentiator
- `img/plan-implementation-in-progress.png` — shows autonomous code execution with live logs

**Format:** Standard GitHub Markdown image syntax: `![Alt text](img/filename.png)`. Each image should be preceded by a short bold label. No HTML wrappers needed — GitHub renders Markdown images inline.

**Why:** The README currently has no visuals. Screenshots give prospective users an immediate understanding of the UI without needing to clone and run the project.

---

### 2. `user-guide.html`

**What to change:**

1. **Add CSS for screenshot images** — Insert a `.screenshot` rule in the existing `<style>` block (after the `.screenshot-placeholder` rule, around line 225) that renders images at full container width with a border, rounded corners, and bottom margin, consistent with the existing visual style:
   - `max-width: 100%`
   - `border: 1px solid var(--border)`
   - `border-radius: var(--radius)`
   - `margin-bottom: 1.5rem`
   - `display: block`

2. **Add images to each relevant section** using `<img class="screenshot" src="img/FILENAME.png" alt="DESCRIPTION">` tags. Placement within each section:

   | Section | Image file | Placement |
   |---|---|---|
   | **2. Projects** — Project Navigation subsection | `img/tasks.png` | After the navigation table (line ~302) — shows the Tasks page as an example of project navigation |
   | **3. Integrations** — GitHub subsection | `img/repositories.png` | After the GitHub ordered list (after the `<div class="callout warning">` block, around line 347) — illustrates the repository selection step |
   | **4. Channels** — Managing Channels subsection | `img/channels.png` | After the Managing Channels `<ul>` list (line ~406) — shows the channel overview page |
   | **6. Tasks** — Reviewing Pending Tasks subsection | `img/tasks.png` | After the ordered list for reviewing tasks (around line ~476) — shows the tasks list with pending review items |
   | **6. Tasks** — Approving a Task subsection | `img/task-generate-plan.png` | After the approval instructions bullet list (around line ~486) — shows the approve/generate plan action |
   | **7. Plans** — Reviewing a Plan subsection | `img/task-plan-generated.png` | After the plan review bullet list (around line ~526) — shows the plan content with action buttons |
   | **7. Plans** — Plan Lifecycle subsection | `img/task-plan-processing.png` | After the flow diagram (around line ~519) — shows the draft/awaiting approval state |
   | **8. Execution** — Live Logs subsection | `img/plan-implementation-in-progress.png` | After the Live Logs paragraph (around line ~571) — shows the SSE log stream in real-time |
   | **8. Execution** — After the PR is Created subsection | `img/plan-completed.png` | After the merged-PR bullet list (around line ~582) — shows the completed plan with DONE status |

**Why:** The user guide already has the `.screenshot-placeholder` CSS class defined but it is never used — the author intended to add images later. These 8 images cover all major user-facing flows. Placing them directly after the relevant descriptive text gives visual confirmation of what each section describes.

---

## Files to Create

None. All 8 images already exist in `img/` at the repository root. No new files need to be created; the `img/` directory just needs to be committed to version control (it is not excluded by `.gitignore`).

---

## Implementation Steps

1. **Verify `img/` is tracked** — Run `git status` to confirm the `img/` folder appears as untracked. Stage it with `git add img/`.

2. **Edit `README.md`** — Insert the `## Screenshots` section after the `## Workflow` section (line 123). Use this structure:
   ```
   ## Screenshots

   **Tasks**
   ![Tasks](img/tasks.png)

   **Channels**
   ![Channels](img/channels.png)

   **Generated Plan**
   ![Generated Plan](img/task-plan-generated.png)

   **Execution in Progress**
   ![Execution in Progress](img/plan-implementation-in-progress.png)
   ```

3. **Edit `user-guide.html` — Add CSS** — In the `<style>` block, after the `.screenshot-placeholder` rule (line ~225), add a `.screenshot` rule as described above.

4. **Edit `user-guide.html` — Section 2 (Projects)** — After the project navigation `<table>` closing tag (line ~302), insert `<img class="screenshot" src="img/tasks.png" alt="Tasks page showing project task list">`.

5. **Edit `user-guide.html` — Section 3 (Integrations, GitHub)** — After the GitHub `<div class="callout warning">` closing tag (line ~347), insert `<img class="screenshot" src="img/repositories.png" alt="Repositories page for selecting GitHub repositories">`.

6. **Edit `user-guide.html` — Section 4 (Channels, Managing Channels)** — After the Managing Channels `</ul>` closing tag (line ~406), insert `<img class="screenshot" src="img/channels.png" alt="Channels page showing configured message channels">`.

7. **Edit `user-guide.html` — Section 6 (Tasks, Reviewing Pending Tasks)** — After the reviewing tasks `</ol>` (around line ~476), insert `<img class="screenshot" src="img/tasks.png" alt="Task list with pending review items">`.

8. **Edit `user-guide.html` — Section 6 (Tasks, Approving a Task)** — After the approval instructions `</ul>` and the following `<p>` paragraph (around line ~486), insert `<img class="screenshot" src="img/task-generate-plan.png" alt="Task detail with Generate Plan action">`.

9. **Edit `user-guide.html` — Section 7 (Plans, Plan Lifecycle flow diagram)** — After the `</div>` closing the flow diagram (around line ~519), insert `<img class="screenshot" src="img/task-plan-processing.png" alt="Plan in draft or awaiting approval state">`.

10. **Edit `user-guide.html` — Section 7 (Plans, Reviewing a Plan)** — After the plan review bullet `</ul>` (around line ~526), insert `<img class="screenshot" src="img/task-plan-generated.png" alt="Plan review page with approve, request changes, and reject actions">`.

11. **Edit `user-guide.html` — Section 8 (Execution, Live Logs)** — After the Live Logs `<p>` paragraph (around line ~571), insert `<img class="screenshot" src="img/plan-implementation-in-progress.png" alt="Live execution log stream during plan execution">`.

12. **Edit `user-guide.html` — Section 8 (Execution, After the PR is Created)** — After the merged-PR `</ul>` list (around line ~582), insert `<img class="screenshot" src="img/plan-completed.png" alt="Completed plan with task marked as DONE and PR created">`.

---

## Testing & Validation

- Open `user-guide.html` directly in a browser (file:// URL) from the repository root and verify all 9 image placements render correctly (note: `tasks.png` appears in two sections — Projects and Tasks — which is intentional).
- Confirm images do not overflow the `860px` container width at standard viewport sizes.
- Push to GitHub and verify the `README.md` images render correctly in the GitHub repository view (GitHub renders Markdown images from relative paths in the same repo).
- Check that the `img/` folder is committed and visible in the GitHub file tree.

---

## Risks & Assumptions

- **`img/` folder location**: The images are assumed to be at the repository root in an `img/` folder. Both `README.md` and `user-guide.html` live at the repo root, so relative paths `img/filename.png` will resolve correctly from both files.
- **Image dimensions**: No specific sizes are assumed. The CSS rule uses `max-width: 100%` so images will scale to fit the guide's 860px container regardless of actual pixel dimensions.
- **`tasks.png` used twice in user-guide.html**: This is intentional — the same screenshot illustrates both the Project Navigation section (as an example of what a project page looks like) and the Tasks section (for reviewing pending tasks). If the owner prefers not to repeat it, the Section 2 instance can be removed.
- **No `img` alt tags in README**: GitHub Markdown alt text is used for accessibility but images render without captions; if the owner wants explicit captions under images, the README structure should use HTML `<figure>/<figcaption>` instead of plain Markdown syntax. The simpler Markdown approach is used here to stay consistent with the rest of the README.
